### PR TITLE
Refactor: Improve code quality, security, and clarity

### DIFF
--- a/configs/settings.py
+++ b/configs/settings.py
@@ -22,8 +22,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-(1y*htyzm+2bx@%bn#4=l8#u!#z1m1vf+4t0u_07ea_72)pbl5'
+# SECURITY WARNING: `DJANGO_SECRET_KEY` must be set in the environment with a strong, unique value for production!
+# The fallback key is for development purposes ONLY and is insecure.
+SECRET_KEY = os.getenv('DJANGO_SECRET_KEY', 'a-default-fallback-key-for-development-only')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/economyApp/tests.py
+++ b/economyApp/tests.py
@@ -1,0 +1,109 @@
+import os
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+from unittest.mock import patch, MagicMock
+import requests # Required for requests.exceptions.RequestException
+
+# Ensure .env is loaded for tests if not already handled by manage.py test
+from dotenv import load_dotenv
+load_dotenv()
+
+
+class AnalyticSentimentViewSetTests(APITestCase):
+    @patch('economyApp.views.requests.get')
+    def test_get_economy_fiscal_sentiment_success(self, mock_get):
+        # Configure the mock_get object for a successful response
+        mock_response_data = {'some': 'data', 'feed': [{'title': 'Fiscal News'}]}
+        mock_api_response = MagicMock()
+        mock_api_response.status_code = 200
+        mock_api_response.json.return_value = mock_response_data
+        # mock_api_response.raise_for_status = MagicMock() # Not strictly needed if status_code is 200
+        mock_get.return_value = mock_api_response
+
+        # Define expected values
+        expected_success_message = "Fiscal economy data fetched successfully"
+        url = reverse('economyApp:economy-fiscal') # as derived
+
+        # Make the GET request
+        response = self.client.get(url)
+
+        # Assert response status code
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # Assert response data structure
+        self.assertEqual(response.data['status'], 'success')
+        self.assertEqual(response.data['messages'], expected_success_message)
+        self.assertEqual(response.data['data'], mock_response_data)
+
+        # Assert that requests.get was called correctly
+        ALPHA_API_KEY = os.getenv("ALPHA_API_KEY")
+        ALPHA_BASE_URL = os.getenv("ALPHA_BASE_URL")
+        # Ensure these are not None for the test to be meaningful
+        self.assertIsNotNone(ALPHA_API_KEY, "ALPHA_API_KEY should be set in environment for this test")
+        self.assertIsNotNone(ALPHA_BASE_URL, "ALPHA_BASE_URL should be set in environment for this test")
+        
+        expected_url = f"{ALPHA_BASE_URL}/query?function=NEWS_SENTIMENT&apikey={ALPHA_API_KEY}&topics=economy_fiscal"
+        mock_get.assert_called_once_with(expected_url)
+        mock_api_response.raise_for_status.assert_called_once()
+
+
+    @patch('economyApp.views.requests.get')
+    def test_get_economy_fiscal_sentiment_api_error(self, mock_get):
+        # Configure the mock_get to raise a requests.exceptions.RequestException
+        api_error_message = "API connection error"
+        mock_get.side_effect = requests.exceptions.RequestException(api_error_message)
+
+        # Define the URL
+        url = reverse('economyApp:economy-fiscal')
+
+        # Make the GET request
+        response = self.client.get(url)
+
+        # Assert response status code
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        # Assert response data structure
+        self.assertEqual(response.data['status'], 'error')
+        self.assertEqual(response.data['messages'], api_error_message)
+        self.assertIsNone(response.data['data'])
+        
+        # Assert that requests.get was called (even though it failed)
+        ALPHA_API_KEY = os.getenv("ALPHA_API_KEY")
+        ALPHA_BASE_URL = os.getenv("ALPHA_BASE_URL")
+        # Ensure these are not None for the test to be meaningful
+        self.assertIsNotNone(ALPHA_API_KEY, "ALPHA_API_KEY should be set in environment for this test")
+        self.assertIsNotNone(ALPHA_BASE_URL, "ALPHA_BASE_URL should be set in environment for this test")
+
+        expected_url = f"{ALPHA_BASE_URL}/query?function=NEWS_SENTIMENT&apikey={ALPHA_API_KEY}&topics=economy_fiscal"
+        mock_get.assert_called_once_with(expected_url)
+
+    @patch('economyApp.views.requests.get')
+    def test_get_economy_fiscal_sentiment_http_error(self, mock_get):
+        # Configure the mock_get object for a failed HTTP response (e.g., 401, 403, 429)
+        mock_api_response = MagicMock()
+        mock_api_response.status_code = 401 # Example: Unauthorized
+        mock_api_response.reason = "Unauthorized"
+        mock_api_response.json.return_value = {'error': 'Invalid API Key'}
+        # Configure raise_for_status to simulate an HTTPError
+        mock_api_response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            f"{mock_api_response.status_code} Client Error: {mock_api_response.reason} for url: FAKE_URL", 
+            response=mock_api_response
+        )
+        mock_get.return_value = mock_api_response
+
+        url = reverse('economyApp:economy-fiscal')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(response.data['status'], 'error')
+        # The message in error_response comes from str(e), where e is RequestException.
+        # For HTTPError, this string representation includes the status code, reason, and URL.
+        self.assertTrue(f"{mock_api_response.status_code} Client Error: {mock_api_response.reason}" in response.data['messages'])
+        self.assertIsNone(response.data['data'])
+
+        ALPHA_API_KEY = os.getenv("ALPHA_API_KEY")
+        ALPHA_BASE_URL = os.getenv("ALPHA_BASE_URL")
+        expected_url = f"{ALPHA_BASE_URL}/query?function=NEWS_SENTIMENT&apikey={ALPHA_API_KEY}&topics=economy_fiscal"
+        mock_get.assert_called_once_with(expected_url)
+        mock_api_response.raise_for_status.assert_called_once()

--- a/economyApp/views.py
+++ b/economyApp/views.py
@@ -12,6 +12,16 @@ ALPHA_API_KEY = os.getenv("ALPHA_API_KEY")
 ALPHA_BASE_URL = os.getenv("ALPHA_BASE_URL")
 
 class AnalyticSentimentViewSet(viewsets.ViewSet):
+    def _fetch_alpha_vantage_data(self, topics: str, success_message: str):
+        url = f"{ALPHA_BASE_URL}/query?function=NEWS_SENTIMENT&apikey={ALPHA_API_KEY}&topics={topics}"
+        try:
+            response = requests.get(url)
+            response.raise_for_status()
+            data = response.json()
+            return success_response(data=data, message=success_message)
+        except requests.RequestException as e:
+            return error_response(message=str(e), code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
     @extend_schema(
         summary="Most Trend Topics About Fiscal Economics Policy",
         description="Returns fiscal economic data analysis.",
@@ -23,14 +33,7 @@ class AnalyticSentimentViewSet(viewsets.ViewSet):
     )
     @action(detail=False, methods=["get"], url_path="fiscal")
     def get_economy_fiscal_sentiment(self, request):
-        url = f"{ALPHA_BASE_URL}/query?function=NEWS_SENTIMENT&apikey={ALPHA_API_KEY}&topics=economy_fiscal"
-        try:
-            response = requests.get(url)
-            response.raise_for_status()
-            data = response.json()
-            return success_response(data=data, message="Fiscal economy data fetched successfully")
-        except requests.RequestException as e:
-            return error_response(message=str(e), code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return self._fetch_alpha_vantage_data(topics="economy_fiscal", success_message="Fiscal economy data fetched successfully")
 
     @extend_schema(
         summary="Data Monetary Economics and Public Responses",
@@ -43,14 +46,7 @@ class AnalyticSentimentViewSet(viewsets.ViewSet):
     )
     @action(detail=False, methods=["get"], url_path="monetary")
     def get_economy_monetary_sentiment(self, request):
-        url = f"{ALPHA_BASE_URL}/query?function=NEWS_SENTIMENT&apikey={ALPHA_API_KEY}&topics=economy_monetary"
-        try:
-            response = requests.get(url)
-            response.raise_for_status()
-            data = response.json()
-            return success_response(data=data, message="Monetary economy data fetched successfully")
-        except requests.RequestException as e:
-            return error_response(message=str(e), code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return self._fetch_alpha_vantage_data(topics="economy_monetary", success_message="Monetary economy data fetched successfully")
 
     @extend_schema(
         summary="Most Trend About Macro Economics",
@@ -63,11 +59,4 @@ class AnalyticSentimentViewSet(viewsets.ViewSet):
     )
     @action(detail=False, methods=["get"], url_path="macro")
     def get_economy_macro_sentiment(self, request):
-        url = f"{ALPHA_BASE_URL}/query?function=NEWS_SENTIMENT&apikey={ALPHA_API_KEY}&topics=economy_macro"
-        try:
-            response = requests.get(url)
-            response.raise_for_status()
-            data = response.json()
-            return success_response(data=data, message="Macro economy data fetched successfully")
-        except requests.RequestException as e:
-            return error_response(message=str(e), code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return self._fetch_alpha_vantage_data(topics="economy_macro", success_message="Macro economy data fetched successfully")

--- a/financeApp/views.py
+++ b/financeApp/views.py
@@ -19,6 +19,24 @@ FMP_API_KEY = os.getenv("FMP_API_KEY")
 FMP_BASE_URL = os.getenv("FMP_BASE_URL")
 
 class FinancialDataViewSet(viewsets.ViewSet):
+    def _fetch_fmp_data(self, api_path: str, serializer_class, success_message: str, data_limit: int = None):
+        url = f"{FMP_BASE_URL}/{api_path}?apikey={FMP_API_KEY}"
+        try:
+            response = requests.get(url)
+            response.raise_for_status()
+            raw_data = response.json()
+
+            if data_limit is not None:
+                raw_data = raw_data[:data_limit]
+
+            serializer = serializer_class(data=raw_data, many=True)
+            serializer.is_valid(raise_exception=True)
+
+            return success_response(data=serializer.data, message=success_message)
+        except requests.RequestException as e:
+            return error_response(message=str(e), code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        # Serializer validation errors will be caught by DRF's default exception handler
+
     @extend_schema(
         summary="Most Searched Stocks",
         description="Returns a list of the most searched stocks",
@@ -30,17 +48,12 @@ class FinancialDataViewSet(viewsets.ViewSet):
     )
     @action(detail=False, methods=["get"], url_path="stocks")
     def get_stock_list(self, request):
-        url = f"{FMP_BASE_URL}/stock/list?apikey={FMP_API_KEY}"
-        try:
-            response = requests.get(url)
-            response.raise_for_status()
-            raw_data = response.json()[:100]
-            serializer = StockDataSerializer(data=raw_data, many=True)
-            serializer.is_valid(raise_exception=True)
-
-            return success_response(serializer.data, "Stock list fetched successfully.")
-        except requests.RequestException as e:
-            return error_response(message=str(e), code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return self._fetch_fmp_data(
+            api_path="stock/list",
+            serializer_class=StockDataSerializer,
+            success_message="Stock list fetched successfully.",
+            data_limit=100
+        )
 
     @extend_schema(
         summary="Market Highest Volume",
@@ -53,18 +66,11 @@ class FinancialDataViewSet(viewsets.ViewSet):
     )
     @action(detail=False, methods=["get"], url_path="volume")
     def get_market_highest_volume(self, request):
-        url = f"{FMP_BASE_URL}/stock_market/actives?apikey={FMP_API_KEY}"
-        try:
-            response = requests.get(url)
-            response.raise_for_status()
-            raw_data = response.json()
-
-            serializer = MarketActiveStockSerializer(data=raw_data, many=True)
-            serializer.is_valid(raise_exception=True)
-
-            return success_response(serializer.data, "High volume stocks fetched successfully.")
-        except requests.RequestException as e:
-            return error_response(message=str(e), code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return self._fetch_fmp_data(
+            api_path="stock_market/actives",
+            serializer_class=MarketActiveStockSerializer,
+            success_message="High volume stocks fetched successfully."
+        )
 
     @extend_schema(
         summary="Most Sector Performance",
@@ -77,18 +83,11 @@ class FinancialDataViewSet(viewsets.ViewSet):
     )
     @action(detail=False, methods=["get"], url_path="sector")
     def get_sector_performance(self, request):
-        url = f"{FMP_BASE_URL}/sector-performance?apikey={FMP_API_KEY}"
-        try:
-            response = requests.get(url)
-            response.raise_for_status()
-            raw_data = response.json()
-
-            serializer = SectorPerformanceSerializer(data=raw_data, many=True)
-            serializer.is_valid(raise_exception=True)
-
-            return success_response(serializer.data, "Sector performance data retrieved.")
-        except requests.RequestException as e:
-            return error_response(message=str(e), code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return self._fetch_fmp_data(
+            api_path="sector-performance",
+            serializer_class=SectorPerformanceSerializer,
+            success_message="Sector performance data retrieved."
+        )
 
     @extend_schema(
         summary="Most Traded Cryptocurrencies",
@@ -101,18 +100,12 @@ class FinancialDataViewSet(viewsets.ViewSet):
     )
     @action(detail=False, methods=["get"], url_path="crypto")
     def get_crypto_symbols(self, request):
-        url = f"{FMP_BASE_URL}/symbol/available-cryptocurrencies?apikey={FMP_API_KEY}"
-        try:
-            response = requests.get(url)
-            response.raise_for_status()
-            raw_data = response.json()[:100]
-
-            serializer = CryptoDataSerializer(data=raw_data, many=True)
-            serializer.is_valid(raise_exception=True)
-
-            return success_response(serializer.data, "Cryptocurrency data fetched.")
-        except requests.RequestException as e:
-            return error_response(message=str(e), code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return self._fetch_fmp_data(
+            api_path="symbol/available-cryptocurrencies",
+            serializer_class=CryptoDataSerializer,
+            success_message="Cryptocurrency data fetched.",
+            data_limit=100
+        )
 
     @extend_schema(
         summary="Most Stocks Downtrend",
@@ -125,15 +118,9 @@ class FinancialDataViewSet(viewsets.ViewSet):
     )
     @action(detail=False, methods=["get"], url_path="downtrend")
     def get_top_losers(self, request):
-        url = f"{FMP_BASE_URL}/stock_market/losers?apikey={FMP_API_KEY}"
-        try:
-            response = requests.get(url)
-            response.raise_for_status()
-            raw_data = response.json()[:100]
-
-            serializer = DowntrendStockSerializer(data=raw_data, many=True)
-            serializer.is_valid(raise_exception=True)
-
-            return success_response(serializer.data, "Top downtrend stocks retrieved.")
-        except requests.RequestException as e:
-            return error_response(message=str(e), code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return self._fetch_fmp_data(
+            api_path="stock_market/losers",
+            serializer_class=DowntrendStockSerializer,
+            success_message="Top downtrend stocks retrieved.",
+            data_limit=100
+        )


### PR DESCRIPTION
This commit introduces several improvements to the codebase:

1.  **DRY Views**:
    *   I refactored `economyApp.views.AnalyticSentimentViewSet` and `financeApp.views.FinancialDataViewSet` by introducing private helper methods (`_fetch_alpha_vantage_data` and `_fetch_fmp_data` respectively). This significantly reduces code duplication for API calls, error handling, and response formatting.
    *   Hardcoded data slicing (e.g., `[:100]`) in `financeApp.views` is now handled by a `data_limit` parameter in the helper method, making it configurable.

2.  **Security Enhancement**:
    *   The Django `SECRET_KEY` in `configs/settings.py` has been moved to an environment variable (`DJANGO_SECRET_KEY`). I've provided a fallback for development, with clear warnings about its insecurity for production.

3.  **Code Cleanup**:
    *   I identified the `main.py` script as a standalone database connection test and not integrated with the Django application. I recommend you remove it (this commit does not delete it, but I previously suggested it).

4.  **Error Handling Analysis**:
    *   I identified redundancy in HTML error page rendering between `configs/middleware/custom_error.py` and Django's `handlerXXX` views in `configs/urls.py`. Both mechanisms render the same `error.html` template, sometimes leading to double rendering. Future work could streamline this.

5.  **Testing**:
    *   I added illustrative unit tests for `economyApp.views.AnalyticSentimentViewSet` (specifically for `get_economy_fiscal_sentiment`). These tests mock external API calls and verify correct success and error responses, demonstrating how to test the refactored views.

These changes contribute to a more maintainable, secure, and cleaner codebase